### PR TITLE
Fix header template variables for Rider 2023.3+

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -145,7 +145,7 @@ dotnet_naming_symbols.all_members.applicable_kinds = *
 
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
-file_header_template = Copyright (c) 2020-$CURRENT_YEAR$ Koji Hasegawa.\nThis software is released under the MIT License.
+file_header_template = Copyright (c) 2020-${CurrentDate.Year} Koji Hasegawa.\nThis software is released under the MIT License.
 
 # RS0016: Only enable if API files are present
 dotnet_public_api_analyzer.require_api_files = true


### PR DESCRIPTION
see: https://youtrack.jetbrains.com/issue/RIDER-102981/File-Header-Template-variables-no-longer-being-replaced
