### PR TITLE
Add specify directories for publishing in the `files` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "documentationUrl": "https://github.com/nowsprinting/blender-like-sceneview-hotkeys/blob/master/README.md",
   "files": [
     "Documentation~",
+    "Editor",
     "Editor*",
+    "Tests",
     "Tests*",
     "package.json*",
     "LICENSE*",


### PR DESCRIPTION
Maybe the glob rule changed for the `files` field from Node 16.
It seems `*` only applies to files and skips directories.

see: https://github.com/openupm/openupm-pipelines/issues/14
