### PR TITLE
Change RS0030 severity to suggestion for Tests assemblies

### DIFF
--- a/Tests/Editor/BlenderLikeSceneViewHotkeys.Editor.Tests.globalconfig
+++ b/Tests/Editor/BlenderLikeSceneViewHotkeys.Editor.Tests.globalconfig
@@ -4,7 +4,7 @@ is_global = true
 dotnet_diagnostic.CS0618.severity = error
 
 # RS0030: Do not use banned APIs
-dotnet_diagnostic.RS0030.severity = warning
+dotnet_diagnostic.RS0030.severity = suggestion
 
 # Nullable reference type warnings (this package does not use nullable annotations)
 dotnet_diagnostic.CS8597.severity = none


### PR DESCRIPTION
## Summary

Banned API violations in test code are less critical than in shipped code, so lower the RS0030 severity from warning to suggestion in the Tests assembly globalconfig to reduce noise. Non-test assemblies keep error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
